### PR TITLE
Use Material 3 Theme colors and text styles by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0
+
+- Uses Theme colors by default (.primary, .onPrimary, .secondary, .onSecondary)
+- Uses Theme text by default (.titleSmall)
+- Added .isCapsule to give the button a capsule shape, on by default
+
 ## 1.0.5
 
 - Fix license, minor publishing issues

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add the package in your pubspec.yaml dependencies
 
 ```dart
 dependencies:
-  bitcoin_ui: : ^1.0.5
+  bitcoin_ui: : ^2.0.0
 ```
 
 ## Usage
@@ -93,7 +93,7 @@ There are three styles of buttons in the UI Kit
 - BitcoinButtonOutlined
 - BitcoinButtonPlain
 
-They each have optional parameters like, textStyle, width, height, tintColor, textColor (for BitcoinButtonFilled), cornerRadius and the ability to set disabled and isLoading states.
+They each have optional parameters like, textStyle, width, height, tintColor, textColor (for BitcoinButtonFilled), cornerRadius and the ability to set disabled and isLoading states. By default, they use colors from the Flutter Theme and are capsule shaped, although this can be overridden.
 
 ```dart
 BitcoinButtonFilled(

--- a/lib/bitcoin_ui.dart
+++ b/lib/bitcoin_ui.dart
@@ -172,6 +172,7 @@ class BitcoinButtonFilled extends StatelessWidget {
     } else {
       return ElevatedButton(
           style: ButtonStyle(
+            elevation: const MaterialStatePropertyAll(0),
             backgroundColor: MaterialStateProperty.all(buttonColor),
             padding: MaterialStateProperty.all(defaultPadding),
             fixedSize:

--- a/lib/bitcoin_ui.dart
+++ b/lib/bitcoin_ui.dart
@@ -106,10 +106,10 @@ class BitcoinButtonFilled extends StatelessWidget {
   final double width;
   final double height;
   final double cornerRadius;
-  final Color tintColor;
-  final Color textColor;
-  final Color disabledTintColor;
-  final Color disabledTextColor;
+  final Color? tintColor;
+  final Color? textColor;
+  final Color? disabledTintColor;
+  final Color? disabledTextColor;
   final bool disabled;
   final bool isLoading;
   final VoidCallback? onPressed;
@@ -121,10 +121,10 @@ class BitcoinButtonFilled extends StatelessWidget {
     this.width = defaultButtonWidth,
     this.height = defaultButtonHeight,
     this.cornerRadius = defaultCornerRadius,
-    this.tintColor = defaultTintColor,
-    this.textColor = defaultTextColor,
-    this.disabledTintColor = defaultDisabledTintColor,
-    this.disabledTextColor = defaultDisabledTextColor,
+    this.tintColor,
+    this.textColor,
+    this.disabledTintColor,
+    this.disabledTextColor,
     this.disabled = false,
     this.isLoading = false,
     required this.onPressed,
@@ -137,7 +137,9 @@ class BitcoinButtonFilled extends StatelessWidget {
           width: width,
           height: height,
           child: CupertinoButton(
-              color: disabled ? disabledTintColor : tintColor,
+              color: disabled
+                  ? disabledTintColor ?? Theme.of(context).colorScheme.secondary
+                  : tintColor ?? Theme.of(context).colorScheme.primary,
               borderRadius: BorderRadius.all(Radius.circular(cornerRadius)),
               padding: defaultPadding,
               onPressed: disabled
@@ -154,8 +156,11 @@ class BitcoinButtonFilled extends StatelessWidget {
                     )
                   : Text(title,
                       style: textStyle ??
-                          BitcoinTextStyle.title5(
-                              disabled ? disabledTextColor : textColor))));
+                          BitcoinTextStyle.title5(disabled
+                              ? disabledTextColor ??
+                                  Theme.of(context).colorScheme.onSecondary
+                              : textColor ??
+                                  Theme.of(context).colorScheme.onPrimary))));
     } else {
       return ElevatedButton(
           style: ButtonStyle(
@@ -186,8 +191,11 @@ class BitcoinButtonFilled extends StatelessWidget {
               : Text(
                   title,
                   style: textStyle ??
-                      BitcoinTextStyle.title5(
-                          disabled ? disabledTextColor : textColor),
+                      BitcoinTextStyle.title5(disabled
+                          ? disabledTextColor ??
+                              Theme.of(context).colorScheme.onSecondary
+                          : textColor ??
+                              Theme.of(context).colorScheme.onPrimary),
                 ));
     }
   }

--- a/lib/bitcoin_ui.dart
+++ b/lib/bitcoin_ui.dart
@@ -90,15 +90,9 @@ extension BitcoinTextStyle on TextStyle {
 
 // Buttons
 
-const defaultButtonWidth = 315.0;
 const defaultButtonHeight = 48.0;
 const defaultCornerRadius = 5.0;
 const defaultPadding = EdgeInsets.symmetric(vertical: 8, horizontal: 30);
-const defaultTintColor = Color(0xFFF89B2A);
-const defaultTextColor = Color(0xFFFFFFFF);
-const defaultDisabledTintColor = Color(0xFFF4F4F4);
-const defaultDisabledTextColor = Color(0xFFBBBBBB);
-const defaultDisabledOutlineColor = Color(0xFFDEDEDE);
 
 class BitcoinButtonFilled extends StatelessWidget {
   final String title;
@@ -217,48 +211,60 @@ class BitcoinButtonFilled extends StatelessWidget {
 class BitcoinButtonOutlined extends StatelessWidget {
   final String title;
   final TextStyle? textStyle;
-  final double width;
-  final double height;
-  final double cornerRadius;
-  final Color tintColor;
-  final Color disabledTintColor;
+  final double? width;
+  final double? height;
+  final double? cornerRadius;
+  final Color? tintColor;
+  final Color? disabledTintColor;
   final bool disabled;
   final bool isLoading;
+  final bool isCapsule;
   final VoidCallback? onPressed;
 
   const BitcoinButtonOutlined({
     Key? key,
     required this.title,
     this.textStyle,
-    this.width = defaultButtonWidth,
-    this.height = defaultButtonHeight,
-    this.cornerRadius = defaultCornerRadius,
-    this.tintColor = defaultTintColor,
-    this.disabledTintColor = defaultDisabledTintColor,
+    this.width,
+    this.height,
+    this.cornerRadius,
+    this.tintColor,
+    this.disabledTintColor,
     this.disabled = false,
     this.isLoading = false,
+    this.isCapsule = true,
     required this.onPressed,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    // Set conditional button values
+    double screenWidth = MediaQuery.of(context).size.width;
+    double buttonWidth = width ?? screenWidth - 2 * 16;
+    double buttonHeight = height ?? defaultButtonHeight;
+    double buttonCornerRadius =
+        cornerRadius ?? (isCapsule ? buttonHeight / 2 : defaultCornerRadius);
+    Color buttonColor = disabled
+        ? disabledTintColor ?? Theme.of(context).colorScheme.secondary
+        : tintColor ?? Theme.of(context).colorScheme.primary;
+
     if (Platform.isIOS) {
       return SizedBox(
-          width: width,
-          height: height,
+          width: buttonWidth,
+          height: buttonWidth,
           child: OutlinedButton(
               // Can't use CupertinoButton here as it has no ability to set outlines
               style: ButtonStyle(
                 elevation: const MaterialStatePropertyAll(0),
                 backgroundColor: MaterialStateProperty.all(Colors.transparent),
                 padding: MaterialStateProperty.all(defaultPadding),
-                fixedSize: MaterialStatePropertyAll(Size(width, height)),
-                side: MaterialStatePropertyAll(BorderSide(
-                    width: 2.0,
-                    color: disabled ? disabledTintColor : tintColor)),
+                fixedSize:
+                    MaterialStatePropertyAll(Size(buttonWidth, buttonHeight)),
+                side: MaterialStatePropertyAll(
+                    BorderSide(width: 2.0, color: buttonColor)),
                 shape: MaterialStateProperty.all(
                   RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(cornerRadius),
+                    borderRadius: BorderRadius.circular(buttonCornerRadius),
                   ),
                 ),
                 enableFeedback: true,
@@ -270,28 +276,31 @@ class BitcoinButtonOutlined extends StatelessWidget {
                       : onPressed,
               child: isLoading
                   ? SizedBox(
-                      height: height * 0.5,
-                      width: height * 0.5,
+                      height: buttonHeight * 0.5,
+                      width: buttonHeight * 0.5,
                       child: Center(
-                          child: CupertinoActivityIndicator(
-                              color: disabled ? disabledTintColor : tintColor)),
+                          child:
+                              CupertinoActivityIndicator(color: buttonColor)),
                     )
                   : Text(title,
                       style: textStyle ??
-                          BitcoinTextStyle.title5(
-                              disabled ? disabledTintColor : tintColor))));
+                          Theme.of(context)
+                              .textTheme
+                              .titleSmall
+                              ?.copyWith(color: buttonColor))));
     } else {
       return ElevatedButton(
           style: ButtonStyle(
             elevation: const MaterialStatePropertyAll(0),
             backgroundColor: MaterialStateProperty.all(Colors.transparent),
             padding: MaterialStateProperty.all(defaultPadding),
-            fixedSize: MaterialStatePropertyAll(Size(width, height)),
-            side: MaterialStatePropertyAll(BorderSide(
-                width: 2.0, color: disabled ? disabledTintColor : tintColor)),
+            fixedSize:
+                MaterialStatePropertyAll(Size(buttonWidth, buttonHeight)),
+            side: MaterialStatePropertyAll(
+                BorderSide(width: 2.0, color: buttonColor)),
             shape: MaterialStateProperty.all(
               RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(cornerRadius),
+                borderRadius: BorderRadius.circular(buttonCornerRadius),
               ),
             ),
             enableFeedback: true,
@@ -303,8 +312,8 @@ class BitcoinButtonOutlined extends StatelessWidget {
                   : onPressed,
           child: isLoading
               ? SizedBox(
-                  height: height * 0.5,
-                  width: height * 0.5,
+                  height: buttonHeight * 0.5,
+                  width: buttonHeight * 0.5,
                   child: Center(
                       child: CircularProgressIndicator(
                           color: disabled ? disabledTintColor : tintColor,
@@ -313,8 +322,10 @@ class BitcoinButtonOutlined extends StatelessWidget {
               : Text(
                   title,
                   style: textStyle ??
-                      BitcoinTextStyle.title5(
-                          disabled ? disabledTintColor : tintColor),
+                      Theme.of(context)
+                          .textTheme
+                          .titleSmall
+                          ?.copyWith(color: buttonColor),
                 ));
     }
   }
@@ -323,38 +334,51 @@ class BitcoinButtonOutlined extends StatelessWidget {
 class BitcoinButtonPlain extends StatelessWidget {
   final String title;
   final TextStyle? textStyle;
-  final double width;
-  final double height;
-  final double cornerRadius;
-  final Color tintColor;
-  final Color disabledTintColor;
+  final double? width;
+  final double? height;
+  final double? cornerRadius;
+  final Color? tintColor;
+  final Color? disabledTintColor;
   final bool disabled;
   final bool isLoading;
+  final bool isCapsule;
   final VoidCallback? onPressed;
 
   const BitcoinButtonPlain({
     Key? key,
     required this.title,
     this.textStyle,
-    this.width = defaultButtonWidth,
-    this.height = defaultButtonHeight,
-    this.cornerRadius = defaultCornerRadius,
-    this.tintColor = defaultTintColor,
-    this.disabledTintColor = defaultDisabledTintColor,
+    this.width,
+    this.height,
+    this.cornerRadius,
+    this.tintColor,
+    this.disabledTintColor,
     this.disabled = false,
     this.isLoading = false,
+    this.isCapsule = true,
     required this.onPressed,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    // Set conditional button values
+    double screenWidth = MediaQuery.of(context).size.width;
+    double buttonWidth = width ?? screenWidth - 2 * 16;
+    double buttonHeight = height ?? defaultButtonHeight;
+    double buttonCornerRadius =
+        cornerRadius ?? (isCapsule ? buttonHeight / 2 : defaultCornerRadius);
+    Color buttonColor = disabled
+        ? disabledTintColor ?? Theme.of(context).colorScheme.secondary
+        : tintColor ?? Theme.of(context).colorScheme.primary;
+
     if (Platform.isIOS) {
       return SizedBox(
-          width: width,
-          height: height,
+          width: buttonWidth,
+          height: buttonHeight,
           child: CupertinoButton(
               color: Colors.transparent,
-              borderRadius: BorderRadius.all(Radius.circular(cornerRadius)),
+              borderRadius:
+                  BorderRadius.all(Radius.circular(buttonCornerRadius)),
               padding: defaultPadding,
               onPressed: disabled
                   ? null
@@ -363,26 +387,28 @@ class BitcoinButtonPlain extends StatelessWidget {
                       : onPressed,
               child: isLoading
                   ? SizedBox(
-                      height: height * 0.5,
-                      width: height * 0.5,
+                      height: buttonHeight * 0.5,
+                      width: buttonHeight * 0.5,
                       child: Center(
-                          child: CupertinoActivityIndicator(
-                              color: disabled ? disabledTintColor : tintColor)),
+                          child:
+                              CupertinoActivityIndicator(color: buttonColor)),
                     )
                   : Text(title,
                       style: textStyle ??
-                          BitcoinTextStyle.title5(
-                              disabled ? disabledTintColor : tintColor))));
+                          Theme.of(context)
+                              .textTheme
+                              .titleSmall
+                              ?.copyWith(color: buttonColor))));
     } else {
       return ElevatedButton(
           style: ButtonStyle(
             elevation: const MaterialStatePropertyAll(0),
             backgroundColor: MaterialStateProperty.all(Colors.transparent),
             padding: MaterialStateProperty.all(defaultPadding),
-            fixedSize: MaterialStatePropertyAll(Size(width, height)),
+            fixedSize: MaterialStatePropertyAll(Size(buttonWidth, buttonWidth)),
             shape: MaterialStateProperty.all(
               RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(cornerRadius),
+                borderRadius: BorderRadius.circular(buttonCornerRadius),
               ),
             ),
             enableFeedback: true,
@@ -394,18 +420,19 @@ class BitcoinButtonPlain extends StatelessWidget {
                   : onPressed,
           child: isLoading
               ? SizedBox(
-                  height: height * 0.5,
-                  width: height * 0.5,
+                  height: buttonHeight * 0.5,
+                  width: buttonHeight * 0.5,
                   child: Center(
                       child: CircularProgressIndicator(
-                          color: disabled ? disabledTintColor : tintColor,
-                          strokeWidth: 2)),
+                          color: buttonColor, strokeWidth: 2)),
                 )
               : Text(
                   title,
                   style: textStyle ??
-                      BitcoinTextStyle.title5(
-                          disabled ? disabledTintColor : tintColor),
+                      Theme.of(context)
+                          .textTheme
+                          .titleSmall
+                          ?.copyWith(color: buttonColor),
                 ));
     }
   }

--- a/lib/bitcoin_ui.dart
+++ b/lib/bitcoin_ui.dart
@@ -164,8 +164,9 @@ class BitcoinButtonFilled extends StatelessWidget {
     } else {
       return ElevatedButton(
           style: ButtonStyle(
-            backgroundColor: MaterialStateProperty.all(
-                disabled ? disabledTintColor : tintColor),
+            backgroundColor: MaterialStateProperty.all(disabled
+                ? disabledTintColor ?? Theme.of(context).colorScheme.secondary
+                : tintColor ?? Theme.of(context).colorScheme.primary),
             padding: MaterialStateProperty.all(defaultPadding),
             fixedSize: MaterialStatePropertyAll(Size(width, height)),
             shape: MaterialStateProperty.all(

--- a/lib/bitcoin_ui.dart
+++ b/lib/bitcoin_ui.dart
@@ -139,7 +139,7 @@ class BitcoinButtonFilled extends StatelessWidget {
     double buttonWidth = width ?? screenWidth - 2 * 16;
     double buttonHeight = height ?? defaultButtonHeight;
     double buttonCornerRadius =
-        isCapsule ? buttonHeight / 2 : cornerRadius ?? defaultCornerRadius;
+        cornerRadius ?? (isCapsule ? buttonHeight / 2 : defaultCornerRadius);
     Color buttonColor = disabled
         ? disabledTintColor ?? Theme.of(context).colorScheme.secondary
         : tintColor ?? Theme.of(context).colorScheme.primary;

--- a/lib/bitcoin_ui.dart
+++ b/lib/bitcoin_ui.dart
@@ -251,7 +251,7 @@ class BitcoinButtonOutlined extends StatelessWidget {
     if (Platform.isIOS) {
       return SizedBox(
           width: buttonWidth,
-          height: buttonWidth,
+          height: buttonHeight,
           child: OutlinedButton(
               // Can't use CupertinoButton here as it has no ability to set outlines
               style: ButtonStyle(
@@ -405,7 +405,8 @@ class BitcoinButtonPlain extends StatelessWidget {
             elevation: const MaterialStatePropertyAll(0),
             backgroundColor: MaterialStateProperty.all(Colors.transparent),
             padding: MaterialStateProperty.all(defaultPadding),
-            fixedSize: MaterialStatePropertyAll(Size(buttonWidth, buttonWidth)),
+            fixedSize:
+                MaterialStatePropertyAll(Size(buttonWidth, buttonHeight)),
             shape: MaterialStateProperty.all(
               RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(buttonCornerRadius),

--- a/lib/bitcoin_ui.dart
+++ b/lib/bitcoin_ui.dart
@@ -104,14 +104,15 @@ class BitcoinButtonFilled extends StatelessWidget {
   final String title;
   final TextStyle? textStyle;
   final double? width;
-  final double height;
-  final double cornerRadius;
+  final double? height;
+  final double? cornerRadius;
   final Color? tintColor;
   final Color? textColor;
   final Color? disabledTintColor;
   final Color? disabledTextColor;
   final bool disabled;
   final bool isLoading;
+  final bool isCapsule;
   final VoidCallback? onPressed;
 
   const BitcoinButtonFilled({
@@ -119,29 +120,41 @@ class BitcoinButtonFilled extends StatelessWidget {
     required this.title,
     this.textStyle,
     this.width,
-    this.height = defaultButtonHeight,
-    this.cornerRadius = defaultCornerRadius,
+    this.height,
+    this.cornerRadius,
     this.tintColor,
     this.textColor,
     this.disabledTintColor,
     this.disabledTextColor,
     this.disabled = false,
     this.isLoading = false,
+    this.isCapsule = true,
     required this.onPressed,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    // Set conditional button values
     double screenWidth = MediaQuery.of(context).size.width;
+    double buttonWidth = width ?? screenWidth - 2 * 16;
+    double buttonHeight = height ?? defaultButtonHeight;
+    double buttonCornerRadius =
+        isCapsule ? buttonHeight / 2 : cornerRadius ?? defaultCornerRadius;
+    Color buttonColor = disabled
+        ? disabledTintColor ?? Theme.of(context).colorScheme.secondary
+        : tintColor ?? Theme.of(context).colorScheme.primary;
+    Color buttonTextColor = disabled
+        ? disabledTextColor ?? Theme.of(context).colorScheme.onSecondary
+        : textColor ?? Theme.of(context).colorScheme.onPrimary;
+
     if (Platform.isIOS) {
       return SizedBox(
-          width: width ?? screenWidth - 2 * 16,
+          width: buttonWidth,
           height: height,
           child: CupertinoButton(
-              color: disabled
-                  ? disabledTintColor ?? Theme.of(context).colorScheme.secondary
-                  : tintColor ?? Theme.of(context).colorScheme.primary,
-              borderRadius: BorderRadius.all(Radius.circular(cornerRadius)),
+              color: buttonColor,
+              borderRadius:
+                  BorderRadius.all(Radius.circular(buttonCornerRadius)),
               padding: defaultPadding,
               onPressed: disabled
                   ? null
@@ -150,35 +163,28 @@ class BitcoinButtonFilled extends StatelessWidget {
                       : onPressed,
               child: isLoading
                   ? SizedBox(
-                      height: height * 0.5,
-                      width: height * 0.5,
+                      height: buttonHeight * 0.5,
+                      width: buttonHeight * 0.5,
                       child: Center(
                           child: CupertinoActivityIndicator(
-                              color: textColor ??
-                                  Theme.of(context).colorScheme.onPrimary)),
+                              color: buttonTextColor)),
                     )
                   : Text(title,
                       style: textStyle ??
-                          Theme.of(context).textTheme.titleSmall?.copyWith(
-                              color: disabled
-                                  ? disabledTextColor ??
-                                      Theme.of(context).colorScheme.onSecondary
-                                  : textColor ??
-                                      Theme.of(context)
-                                          .colorScheme
-                                          .onPrimary))));
+                          Theme.of(context)
+                              .textTheme
+                              .titleSmall
+                              ?.copyWith(color: buttonTextColor))));
     } else {
       return ElevatedButton(
           style: ButtonStyle(
-            backgroundColor: MaterialStateProperty.all(disabled
-                ? disabledTintColor ?? Theme.of(context).colorScheme.secondary
-                : tintColor ?? Theme.of(context).colorScheme.primary),
+            backgroundColor: MaterialStateProperty.all(buttonColor),
             padding: MaterialStateProperty.all(defaultPadding),
-            fixedSize: MaterialStatePropertyAll(
-                Size(width ?? screenWidth - 2 * 16, height)),
+            fixedSize:
+                MaterialStatePropertyAll(Size(buttonWidth, buttonHeight)),
             shape: MaterialStateProperty.all(
               RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(cornerRadius),
+                borderRadius: BorderRadius.circular(buttonCornerRadius),
               ),
             ),
             enableFeedback: true,
@@ -190,23 +196,19 @@ class BitcoinButtonFilled extends StatelessWidget {
                   : onPressed,
           child: isLoading
               ? SizedBox(
-                  height: height * 0.5,
-                  width: height * 0.5,
+                  height: buttonHeight * 0.5,
+                  width: buttonHeight * 0.5,
                   child: Center(
                       child: CircularProgressIndicator(
-                          color: textColor ??
-                              Theme.of(context).colorScheme.onPrimary,
-                          strokeWidth: 2)),
+                          color: buttonTextColor, strokeWidth: 2)),
                 )
               : Text(
                   title,
                   style: textStyle ??
-                      Theme.of(context).textTheme.titleSmall?.copyWith(
-                          color: disabled
-                              ? disabledTextColor ??
-                                  Theme.of(context).colorScheme.onSecondary
-                              : textColor ??
-                                  Theme.of(context).colorScheme.onPrimary),
+                      Theme.of(context)
+                          .textTheme
+                          .titleSmall
+                          ?.copyWith(color: buttonTextColor),
                 ));
     }
   }

--- a/lib/bitcoin_ui.dart
+++ b/lib/bitcoin_ui.dart
@@ -103,7 +103,7 @@ const defaultDisabledOutlineColor = Color(0xFFDEDEDE);
 class BitcoinButtonFilled extends StatelessWidget {
   final String title;
   final TextStyle? textStyle;
-  final double width;
+  final double? width;
   final double height;
   final double cornerRadius;
   final Color? tintColor;
@@ -118,7 +118,7 @@ class BitcoinButtonFilled extends StatelessWidget {
     Key? key,
     required this.title,
     this.textStyle,
-    this.width = defaultButtonWidth,
+    this.width,
     this.height = defaultButtonHeight,
     this.cornerRadius = defaultCornerRadius,
     this.tintColor,
@@ -132,9 +132,10 @@ class BitcoinButtonFilled extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    double screenWidth = MediaQuery.of(context).size.width;
     if (Platform.isIOS) {
       return SizedBox(
-          width: width,
+          width: width ?? screenWidth - 2 * 16,
           height: height,
           child: CupertinoButton(
               color: disabled
@@ -152,15 +153,20 @@ class BitcoinButtonFilled extends StatelessWidget {
                       height: height * 0.5,
                       width: height * 0.5,
                       child: Center(
-                          child: CupertinoActivityIndicator(color: textColor)),
+                          child: CupertinoActivityIndicator(
+                              color: textColor ??
+                                  Theme.of(context).colorScheme.onPrimary)),
                     )
                   : Text(title,
                       style: textStyle ??
-                          BitcoinTextStyle.title5(disabled
-                              ? disabledTextColor ??
-                                  Theme.of(context).colorScheme.onSecondary
-                              : textColor ??
-                                  Theme.of(context).colorScheme.onPrimary))));
+                          Theme.of(context).textTheme.titleSmall?.copyWith(
+                              color: disabled
+                                  ? disabledTextColor ??
+                                      Theme.of(context).colorScheme.onSecondary
+                                  : textColor ??
+                                      Theme.of(context)
+                                          .colorScheme
+                                          .onPrimary))));
     } else {
       return ElevatedButton(
           style: ButtonStyle(
@@ -168,7 +174,8 @@ class BitcoinButtonFilled extends StatelessWidget {
                 ? disabledTintColor ?? Theme.of(context).colorScheme.secondary
                 : tintColor ?? Theme.of(context).colorScheme.primary),
             padding: MaterialStateProperty.all(defaultPadding),
-            fixedSize: MaterialStatePropertyAll(Size(width, height)),
+            fixedSize: MaterialStatePropertyAll(
+                Size(width ?? screenWidth - 2 * 16, height)),
             shape: MaterialStateProperty.all(
               RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(cornerRadius),
@@ -187,16 +194,19 @@ class BitcoinButtonFilled extends StatelessWidget {
                   width: height * 0.5,
                   child: Center(
                       child: CircularProgressIndicator(
-                          color: textColor, strokeWidth: 2)),
+                          color: textColor ??
+                              Theme.of(context).colorScheme.onPrimary,
+                          strokeWidth: 2)),
                 )
               : Text(
                   title,
                   style: textStyle ??
-                      BitcoinTextStyle.title5(disabled
-                          ? disabledTextColor ??
-                              Theme.of(context).colorScheme.onSecondary
-                          : textColor ??
-                              Theme.of(context).colorScheme.onPrimary),
+                      Theme.of(context).textTheme.titleSmall?.copyWith(
+                          color: disabled
+                              ? disabledTextColor ??
+                                  Theme.of(context).colorScheme.onSecondary
+                              : textColor ??
+                                  Theme.of(context).colorScheme.onPrimary),
                 ));
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bitcoin_ui
 description: Bitcoin UI for Flutter. Provides UI components like colors, text styles, buttons and more from the Bitcoin UI Kit project by the Bitcoin design community.
-version: 1.0.5
+version: 2.0.0
 homepage: https://github.com/bdgwallet/bitcoinui-flutter
 
 environment:


### PR DESCRIPTION
Instead of using hard coded default colors and text styles, this update uses those from the set Theme.